### PR TITLE
CUR 91 ENG: Replace Request facade to meet standard.

### DIFF
--- a/app/Http/Controllers/ClassController.php
+++ b/app/Http/Controllers/ClassController.php
@@ -2,7 +2,6 @@
 
 
 use Illuminate\Http\Request;
-use Request as RequestInput;
 
 use Curriculum\Handlers\HandlerUtilities;
 use Curriculum\Models\Classes,
@@ -28,13 +27,12 @@ class ClassController extends Controller {
 	public function index(Request $request)
 	{
         $version= $request->route()->getAction()['version'];
-		//$term = HandlerUtilities::getCurrentTermID();
 		$term = Term::current();
 		$term_id = ($term ? $term->term_id : 0);
 		$data = Classes::with('meetings', 'instructors')->where('term_id', $term_id);
 
 		/* APPLY INSTRUCTOR FILTER */
-		$instructor = RequestInput::input('instructor', 0);
+		$instructor = $request->input('instructor', false);
 		if($instructor) {
 			$data->hasInstructor($instructor);
 		} else {
@@ -51,7 +49,7 @@ class ClassController extends Controller {
             'collection'	  => 'classes',
 			'classes'	  => $prepped_data
 		);
-        if(strpos(RequestInput::url(),'api' ) == false){
+        if(strpos($request->url(),'api' ) == false){
             $response = array(
                 'type'		  => 'classes',
                 'classes'	  => $prepped_data
@@ -59,7 +57,7 @@ class ClassController extends Controller {
             return HandlerUtilities::sendLegacyResponse($response);
         }
 
-		return HandlerUtilities::sendResponse($responsec,$version);
+		return HandlerUtilities::sendResponse($response,$version);
 	}
 
 	/**
@@ -82,7 +80,6 @@ class ClassController extends Controller {
 	public function show($id, Request $request)
 	{
         $version= $request->route()->getAction()['version'];
-		//$term_id = HandlerUtilities::getCurrentTermID();
 
 		$term = Term::current();
 		$term_id = ($term ? $term->term_id : 0);
@@ -94,7 +91,7 @@ class ClassController extends Controller {
 
 		/* APPLY INSTRUCTOR FILTER */
 
-		$instructor = RequestInput::input('instructor', 0);
+		$instructor = $request->input('instructor', false);
 
 		if($instructor) {
 			$data->hasInstructor($instructor);
@@ -103,11 +100,11 @@ class ClassController extends Controller {
 		$prepped_data = HandlerUtilities::prepareClassesResponse($data->get());
 
 		$response = array(
-			'collection'		  => 'classes',
-			'classes'	  => $prepped_data
+			'collection'	=> 'classes',
+			'classes'	    => $prepped_data
 		);
 
-        if(strpos(RequestInput::url(),'api' ) == false){
+        if(strpos($request->url(),'api' ) == false){
             $response = array(
                 'type'		  => 'classes',
                 'classes'	  => $prepped_data

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -1,7 +1,6 @@
 <?php namespace Curriculum\Http\Controllers;
 
 use Illuminate\Http\Request;;
-use Request as RequestInput;
 use Curriculum\Handlers\HandlerUtilities;
 use Curriculum\Models\Classes,
 	Curriculum\Models\Course,
@@ -28,13 +27,12 @@ class CourseController extends Controller {
 	public function index(Request $request)
 	{
         $version= $request->route()->getAction()['version'];
-		//$term = HandlerUtilities::getCurrentTermID();
 		$term = Term::current();
 		$term_id = ($term ? $term->term_id : 0);
-		$id = Request::input('id', 0);
+		$id = $request->input('id', 0);
 		if($id){
             $data = Classes::whereIdentifier($id)
-                ->groupAsCourse($term_id, Request::input('showAll', false))
+                ->groupAsCourse($term_id, $request->input('showAll', false))
                 ->orderBy('subject')->orderBy('catalog_number');
         }
         else{
@@ -50,7 +48,7 @@ class CourseController extends Controller {
 			'limit'		  => '50',
 			'courses'	  => $prepped_data
 		);
-        if(strpos(RequestInput::url(),'api' ) == false){
+        if(strpos($request->url(),'api' ) == false){
             $response = array(
                 'type'		  => 'courses',
                 'courses'	  => $prepped_data
@@ -73,11 +71,10 @@ class CourseController extends Controller {
 	public function show($id, Request $request)
 	{
         $version= $request->route()->getAction()['version'];
-		//$term = HandlerUtilities::getCurrentTermID();
 		$term = Term::current();
 		$term_id = ($term ? $term->term_id : 0);
 		$data = Classes::whereIdentifier($id)
-			->groupAsCourse($term_id, RequestInput::input('showAll', false))
+			->groupAsCourse($term_id, $request->input('showAll', false))
 			->orderBy('subject')->orderBy('catalog_number');
 
 		$prepped_data = HandlerUtilities::prepareCoursesResponse($data->get());
@@ -86,7 +83,7 @@ class CourseController extends Controller {
 			'courses'	  => $prepped_data
 		);
 
-        if(strpos(RequestInput::url(),'api' ) == false){
+        if(strpos($request->url(),'api' ) == false){
             $response = array(
                 'type'		  => 'courses',
                 'courses'	  => $prepped_data

--- a/app/Http/Controllers/PlanController.php
+++ b/app/Http/Controllers/PlanController.php
@@ -1,7 +1,6 @@
 <?php namespace Curriculum\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Request as RequestInput;
 
 use Curriculum\Handlers\HandlerUtilities;
 use Curriculum\Models\Plan;
@@ -54,7 +53,7 @@ class PlanController extends Controller {
 			'limit'		  => '150',
 			'plans'	  	  => $data
 		);
-        if(strpos(RequestInput::url(),'api' ) == false){
+        if(strpos($request->url(),'api' ) == false){
             $response = array(
                 'type'		  => 'plans',
                 'plans'	  => $data
@@ -82,7 +81,7 @@ class PlanController extends Controller {
 			'plan'	  	    => $data
 		);
 
-        if(strpos(RequestInput::url(),'api' ) == false){
+        if(strpos($request->url(),'api' ) == false){
             $response = array(
                 'type'	    => 'plans',
                 'plans'	    => $data

--- a/app/Http/Controllers/TermController.php
+++ b/app/Http/Controllers/TermController.php
@@ -1,8 +1,6 @@
 <?php namespace Curriculum\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Request as RequestInput;
-
 use Curriculum\Handlers\HandlerUtilities;
 use Curriculum\Models\Classes;
 
@@ -32,8 +30,9 @@ class TermController extends Controller {
 			->where('term_id', $term)
 			->orderBy('subject')->orderBy('catalog_number');
 
-		/* APPLY INSTRUCTOR FILTER */
-		$instructor = RequestInput::input('instructor', 0);
+		/* APPLY INSTRUCTOR AND ID FILTER */
+		$instructor = $request->input('instructor', false);
+		$id = $request->input('id', false);
 		if($instructor) {
 			$data->hasInstructor($instructor);
 		}
@@ -52,7 +51,7 @@ class TermController extends Controller {
 			'classes'	  => $prepped_data
 		);
 
-        if(strpos(RequestInput::url(),'api' ) == false){
+        if(strpos($request->url(),'api' ) == false){
             $response = array(
                 'type'		  => 'classes',
                 'classes'	  => $prepped_data
@@ -89,7 +88,7 @@ class TermController extends Controller {
 			->orderBy('subject')->orderBy('catalog_number');
 
 		/* APPLY INSTRUCTOR FILTER */
-		$instructor = RequestInput::input('instructor', 0);
+		$instructor = $request->input('instructor', false);
 		if($instructor) {
 			$data->hasInstructor($instructor);
 		}
@@ -100,7 +99,7 @@ class TermController extends Controller {
 			'classes'	  => $prepped_data
 		);
 
-        if(strpos(RequestInput::url(),'api' ) == false){
+        if(strpos($request->url(),'api' ) == false){
             $response = array(
                 'type'		  => 'classes',
                 'classes'	  => $prepped_data
@@ -125,10 +124,10 @@ class TermController extends Controller {
         $version= $request->route()->getAction()['version'];
 		$term_code = HandlerUtilities::generateTermCodeFromSemesterTerm($term);
 
-        $id = Request::input('id', 0);
+        $id = $request->input('id', false);
         if($id){
             $data = Classes::whereIdentifier($id)
-                ->groupAsCourse($term_code, Request::input('showAll', false))
+                ->groupAsCourse($term_code, $request->input('showAll', false))
                 ->orderBy('subject')->orderBy('catalog_number');
         }
         else{
@@ -143,7 +142,7 @@ class TermController extends Controller {
 			'courses'	  => $prepped_data
 		);
 
-        if(strpos(RequestInput::url(),'api' ) == false){
+        if(strpos($request->url(),'api' ) == false){
             $response = array(
                 'type'		  => 'courses',
                 'courses'	  => $prepped_data
@@ -174,7 +173,7 @@ class TermController extends Controller {
 		$term_code = HandlerUtilities::generateTermCodeFromSemesterTerm($term);
 
 		$data = Classes::whereIdentifier($id)
-			->groupAsCourse($term_code, RequestInput::input('showAll',false))
+			->groupAsCourse($term_code, $request->input('showAll',false))
 			->orderBy('subject')->orderBy('catalog_number');
 
 
@@ -185,7 +184,7 @@ class TermController extends Controller {
 			'courses'	  => $prepped_data
 		);
 
-        if(strpos(RequestInput::url(),'api' ) == false){
+        if(strpos($request->url(),'api' ) == false){
             $response = array(
                 'type'		  => 'courses',
                 'courses'	  => $prepped_data


### PR DESCRIPTION
Replaced the use of Request:: with ->, and made various other touch ups.



Currently we are using three forms of Request and RequestInput and $request.
To create standard convert all Request to $request.

Leading to singular request variable.

Should preform same results.
