### PR TITLE
CUR-96  Fix the issue where the @sendErrorResponse expects a version parameter on line 244

### DIFF
--- a/app/Handlers/HandlerUtilities.php
+++ b/app/Handlers/HandlerUtilities.php
@@ -7,7 +7,6 @@ use Curriculum\Models\LoggedRequest,
 
 class HandlerUtilities
 {
-
 	/* Place all helper methods here */
 
 

--- a/app/Handlers/HandlerUtilities.php
+++ b/app/Handlers/HandlerUtilities.php
@@ -241,7 +241,7 @@ class HandlerUtilities
 
 		// complete the response
 		$data = array_reverse($data);
-		return self::sendResponse($data, $version='1.0');
+		return self::sendResponse($data);
 	}
 
 	/**
@@ -251,7 +251,7 @@ class HandlerUtilities
 	 * @param array $data The data to send back to the browser
 	 * @return Response
 	 */
-    public static function sendResponse($data, $version) {
+    public static function sendResponse($data, $version='1.1') {
         // additional data to add that should exist for all responses
         $additional = [
             'version' => $version,

--- a/app/Handlers/HandlerUtilities.php
+++ b/app/Handlers/HandlerUtilities.php
@@ -7,6 +7,7 @@ use Curriculum\Models\LoggedRequest,
 
 class HandlerUtilities
 {
+
 	/* Place all helper methods here */
 
 
@@ -241,7 +242,8 @@ class HandlerUtilities
 
 		// complete the response
 		$data = array_reverse($data);
-		return self::sendResponse($data);
+		//In the case of an error, a default version matching the latest version will be shown
+		return self::sendResponse($data,'1.1');
 	}
 
 	/**
@@ -251,7 +253,7 @@ class HandlerUtilities
 	 * @param array $data The data to send back to the browser
 	 * @return Response
 	 */
-    public static function sendResponse($data, $version='1.1') {
+    public static function sendResponse($data, $version) {
         // additional data to add that should exist for all responses
         $additional = [
             'version' => $version,

--- a/app/Handlers/HandlerUtilities.php
+++ b/app/Handlers/HandlerUtilities.php
@@ -241,7 +241,7 @@ class HandlerUtilities
 
 		// complete the response
 		$data = array_reverse($data);
-		return self::sendResponse($data);
+		return self::sendResponse($data, $version='1.0');
 	}
 
 	/**


### PR DESCRIPTION
### `CUR-96` - `PR`
`**READY**`

### What's this PR do?
`This PR removes an error which would be thrown when the URL was typed wrong.  Now, when a URL is typed wrong, the error json will contain the latest version number.`
### Where should the reviewer start?  
`Start at HandlerUtilities@sendErrorResponse line 244, simple change was made`


### Steps to Test or Reproduce
`Outline the steps to test or reproduce the PR here.`

i.e.:
```
try hitting a url that does not exist, ex:
http://localhost/curriculum/public/api/thisisntreal
confirm an error message does not show and json does.
```

### Impacted Areas in Application
`List general components of the application that this PR will affect:`
