### PR TITLE
HOTFIX - appended 'nr' to instructor's email addresses in two test controllers

### DIFF
--- a/tests/ClassControllerTest.php
+++ b/tests/ClassControllerTest.php
@@ -6,7 +6,7 @@ class ClassControllerTest extends TestCase
 
     public function setUp(){
         parent::setUp();
-        $this->validEmail = 'steven.fitzgerald@csun.edu';
+        $this->validEmail = 'nr_steven.fitzgerald@csun.edu';
     }
 
     public function testIndex_returns_json_content_for_version_one()

--- a/tests/TermControllerTest.php
+++ b/tests/TermControllerTest.php
@@ -9,7 +9,7 @@ class TermControllerTest extends TestCase {
 
     public function setUp(){
         parent::setUp();
-        $this->validEmail = 'steven.fitzgerald@csun.edu';
+        $this->validEmail = 'nr_steven.fitzgerald@csun.edu';
         $this->validTerm = 2153;
         $this->validClassId = 19149;
     }


### PR DESCRIPTION
Made changes to ClasControllerTest and PlanControllerTest, email variable changed to append 'nr'.